### PR TITLE
Explicit Missions Directory in Config

### DIFF
--- a/tauntaun_live_editor/config.py
+++ b/tauntaun_live_editor/config.py
@@ -12,6 +12,7 @@ class Config:
     autosave: bool = True
     default_coalition: str = ""
     default_mission: str = ""
+    missions_directory: str = ""
 
 def _get_datadir() -> pathlib.Path:
 
@@ -85,4 +86,3 @@ def load_config(config_path_str = None):
     _ConfigFileManager.save(loaded_config, config_path)
 
     config = loaded_config
-

--- a/tauntaun_live_editor/util.py
+++ b/tauntaun_live_editor/util.py
@@ -1,6 +1,8 @@
 import os
 import asyncio
 import logging
+import tauntaun_live_editor.config as config
+
 
 class Timer:
     def __init__(self, timeout, callback, periodic = False):
@@ -88,6 +90,8 @@ def is_posix():
     return os.name == 'posix'
 
 def get_miz_path():
+    if os.path.exists(config.config.missions_directory):
+        return os.path.join(config.config.missions_directory)
     if is_posix():
         dcs_dir = get_data_path()
     else:


### PR DESCRIPTION
Tauntaun wants to find missions in the wrong DCS saved games folder on my dev build (I have multiple DCS installs), so I added a way to explicitly define the folder through config.  Thought this might be useful to others as well.  

If `missions_directory` is not defined in the config, it uses the same method as before.