### PR TITLE
Updated Python and pyinstaller versions

### DIFF
--- a/.github/workflows/exe.yml
+++ b/.github/workflows/exe.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/exe_release.yml
+++ b/.github/workflows/exe_release.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel==0.36.0
 Quart==0.17.0
-dataclasses-json==0.5.2
+dataclasses-json==0.5.7
 
-pyinstaller==3.6
+pyinstaller>=5.0


### PR DESCRIPTION
Fixes issue #121.

I also modified some Python dependencies in `requirements.txt` to use `>=` instead of fixed versions. I think that using fixed versions (`=<version>`) will create more problems than it solves, in terms of compatibility.