### PR TITLE
Test multiple Python versions using github actions

### DIFF
--- a/.github/workflows/exe.yml
+++ b/.github/workflows/exe.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest   
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/exe.yml
+++ b/.github/workflows/exe.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: windows-latest   
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -20,10 +23,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python 3.9
+      - name: Set up ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/exe_release.yml
+++ b/.github/workflows/exe_release.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: windows-latest   
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -20,10 +23,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Set up Python 3.9
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/exe_release.yml
+++ b/.github/workflows/exe_release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest   
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -23,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y git ssh python3.8 nodejs yarn
+          sudo apt-get install -y git ssh python${{ matrix.python-version}} nodejs yarn
 
       # Runs a set of commands using the runners shell
       - name: Build and test

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,6 +19,9 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -29,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y git ssh python3.8 nodejs yarn
+          sudo apt-get install -y git ssh python${{ matrix.python-version}} nodejs yarn
       # Runs a set of commands using the runners shell
       - name: Build and test
         run: |

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ['3.8', '3.9', '3.10']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Develompent builds are available under [actions](https://github.com/UOAF/project
 Click the top "Build exe" action and on the bottom of the page there should be a link to the dev build "tauntaun_live_editor_\<long number\>".    
 _You need to be logged in to be able to see the download links._    
 I recommend checking dev builds if something is missing(e.g. new weapon) or broken after a DCS patch.
-##### Python 3.8
+##### Python 3.8-3.10
 ##### pip
 ```bash
 pip install wheel # Only on Linux


### PR DESCRIPTION
I noticed PyDCS does this. Running builds on different versions of Python gives us a better idea if something breaks on a certain version and allows us to future-proof the design.