### PR TITLE
Forward to backend if dev server is detected

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "tauntaun_live_editor",
   "version": "0.1.0",
   "private": true,
-  "proxy": "",
+  "proxy": "http://localhost:8080",
   "dependencies": {
     "@types/leaflet": "^1.5.19",
     "bluebird-global": "^1.0.1",

--- a/frontend/src/services/gameService.ts
+++ b/frontend/src/services/gameService.ts
@@ -199,7 +199,14 @@ async function openSocket(port: number): Promise<void> {
     try {
       const url = new URL('/ws/message', window.location.href);
       url.protocol = url.protocol.replace('http', 'ws');
-      url.port = port.toString();
+      const isDevServer = process.env.NODE_ENV === 'development';
+      const isUsingDevDefaultPort = port === 3000;
+      if (isDevServer && isUsingDevDefaultPort) {
+        // ugly hack to forward to 8080 for development...
+        url.port = '8080';
+      } else {
+        url.port = port.toString();
+      }
       socket = new WebSocket(url.toString());
       socket.binaryType = 'arraybuffer';
       socket.onopen = () => resolve();

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3367,9 +3367,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001219:
-  version "1.0.30001228"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz#bfdc5942cd3326fa51ee0b42fbef4da9d492a7fa"
-  integrity sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==
+  version "1.0.30001341"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz"
+  integrity sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
If a node dev server is detected, the frontend will manually forward to the default python backend server port.

To use this, start the python server listening on `8080`. Then run `yarn start`. The dev server should launch listening on port `3000`, and the normal app initialization is run. From then on, any changes to frontend code will be automatically compiled and the server restarted.

This should significantly streamline the workflow for doing frontend work that doesn't touch the backend.